### PR TITLE
Bump curbside cordova plugin version

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+.prettierrc
+scripts
+tests
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
     "name": "curbside-cordova",
-    "version": "3.2.3",
+    "version": "3.5.2",
     "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "curbside-cordova",
-    "version": "3.2.3",
+    "version": "3.5.2",
     "cordova": {
         "id": "curbside-cordova",
         "platforms": [
@@ -11,8 +11,8 @@
     "scripts": {},
     "description": "Curbside Cordova Plugin",
     "author": {
-        "email": "alex.pare.inc@gmail.com",
-        "name": "Alexandre Paré"
+        "email": "platform@rakutenready.com",
+        "name": "Mathieu St-Pierre"
     },
     "repository": {
         "url": "https://github.com/curbside/curbside-cordova"

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin 
-    xmlns="http://apache.org/cordova/ns/plugins/1.0" id="curbside-cordova" version="3.2.3">
+    xmlns="http://apache.org/cordova/ns/plugins/1.0" id="curbside-cordova" version="3.5.2">
     <name>Cordova Plugin Template</name>
     <description></description>
     <license>MIT</license>


### PR DESCRIPTION
For publishing new curbside-cordova plugin to include new methods added for https://github.com/RakutenReady/Team/issues/52651.