### PR TITLE
53303 remove CSMonitoringSession code from cordova plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -570,39 +570,6 @@ document.addEventListener("deviceready", function() {
 
   });
 
-  /**
-   * Completes the trip(s) identified by the trackToken(s) and trackIdentifier to this site.
-   * Call this method when the trip(s) for the given trackToken(s) is/are completed by the user.
-   * If the trackTokens is nil, then all trips to this site for the user will be marked complete.
-   **/
-  Curbside.completeTripForTrackingIdentifier("USER_UNIQUE_TRACKING_ID", ["UNIQUE_TRACK_TOKEN_1", "UNIQUE_TRACK_TOKEN_2"], function(error){
-
-  });
-
-  /**
-   * Cancels the trip(s) identified by the trackToken(s) and trackIdentifier to this site.
-   * Call this method when the trip(s) for the given trackToken(s) is/are cancelled by the user.
-   * If the trackTokens is nil, then all trips to this site for the user will be canceled.
-   **/
-  Curbside.cancelTripForTrackingIdentifier("USER_UNIQUE_TRACKING_ID", ["UNIQUE_TRACK_TOKEN_1", "UNIQUE_TRACK_TOKEN_2"], function(error){
-
-  });
-
-  /**
-   * This subscribes to user arrival and status updates to the site defined by arrivalSite.
-   * If an error occurs because of an invalid session state, permissions or authentication with the ARRIVE server,
-   * Will trigger userStatusUpdates
-   **/
-  Curbside.startMonitoringArrivalsToSiteWithIdentifier("SITE_ID", function(error){
-
-  });
-
-  /**
-   * This unsubscribes to user status updates.
-   **/
-  Curbside.stopMonitoringArrivals(function(error){
-
-  });
 });
 </script>
 ```

--- a/README.md
+++ b/README.md
@@ -61,15 +61,6 @@ In `platforms/ios/YOUR_PROJECT/Classes/AppDelegate.m`
   [userSession application:application didFinishLaunchingWithOptions:launchOptions];
 ```
 
-#### **Monitoring Session**
-
-If your app does not already request location, In `platforms/ios/YOUR_PROJECT/Classes/AppDelegate.m` in `-(BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions` add this:
-
-```objc
-    CSMonitoringSession *monitoringSession = [CSMonitoringSession createSessionWithAPIKey:@"APIKey" secret:@"secret" delegate:nil];
-    [monitoringSession application:application didFinishLaunchingWithOptions:launchOptions];
-```
-
 #### **Configuration**
 
 You can also configure the following variables to customize the iOS location plist entries
@@ -202,28 +193,6 @@ In `platforms/android/app/src/main/java/io/cordova/YOUR_PROJECT/MainActivity.jav
         ...
 ```
 
-or if you whant to have the monitoring session
-
-```java
-    public class MainActivity extends CordovaActivity
-    {
-      private static String API_KEY = "API_KEY";
-      private static String SECRET = "SECRET";
-      private static final int PERMISSION_REQUEST_CODE = 1;
-
-      @Override
-      public void onCreate(final Bundle savedInstanceState) {
-          super.onCreate(savedInstanceState);
-
-          CSMonitoringSession.init(this, new BasicAuthCurbsideCredentialProvider(API_KEY, SECRET));
-
-          if (ActivityCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED &&
-                  ActivityCompat.checkSelfPermission(this, Manifest.permission.ACCESS_COARSE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
-              String[] permissions = new String[]{Manifest.permission.ACCESS_COARSE_LOCATION, Manifest.permission.ACCESS_FINE_LOCATION};
-              ActivityCompat.requestPermissions(this, permissions, PERMISSION_REQUEST_CODE);
-          }
-        ...
-```
 
 In `platforms/android/cordova/lib/config/GradlePropertiesParser.js` turned on useAndroidX:
 
@@ -343,10 +312,10 @@ document.addEventListener("deviceready", function() {
   /**
    * Set the "USER_UNIQUE_TRACKING_ID" of the user currently logged in your app. This may be nil when the app is
    * started, but as the user logs into the app, make sure this value is set. trackingIdentifier needs to be set to use
-   * session specific methods for starting trips or monitoring sites. This identifier will be persisted across
+   * session specific methods for starting trips. This identifier will be persisted across
    * application restarts.
    *
-   * When the user logs out, set this to nil, which will in turn end the user session or monitoring session.
+   * When the user logs out, set this to nil, which will in turn end the user session.
    * Note: The maximum length of the trackingIdentifier is 36 characters.
    **/
   Curbside.setTrackingIdentifier("USER_UNIQUE_TRACKING_ID", function(error){
@@ -503,10 +472,10 @@ document.addEventListener("deviceready", function() {
   });
 
   /**
-   * Call this method to notify the user in the CSMonitoringSession of thearrival of this user at the site "SITE_ID".
+   * Call this method to notify the user in the CSMonitoringSession of the arrival of this user at the site "SITE_ID".
    *
    * If an error occurs because of an invalid session state, permissions orauthentication with the ARRIVE server,
-   * the callback will be informed with the reason as to whynotifyMonitoringSessionUserOfArrivalAtSite failed.
+   * the callback will be informed with the reason as to why notifyMonitoringSessionUserOfArrivalAtSite failed.
    **/ 
   Curbside.notifyMonitoringSessionUserOfArrivalAtSite("SITE_ID", function(error){
 
@@ -538,41 +507,6 @@ document.addEventListener("deviceready", function() {
 </script>
 ```
 
-### For Monitoring Session
-
-```html
-<script type="text/javascript">
-document.addEventListener("deviceready", function() {
-   /**
-   * Will be triggered when user status updates are sent to the consuming application.
-   **/
-  Curbside.on("userStatusUpdates", function(UserStatusUpdates){
-    // Do something
-  });
-
-  /**
-   * Set the "USER_UNIQUE_TRACKING_ID" of the user currently logged in your app. This may be nil when the app is
-   * started, but as the user logs into the app, make sure this value is set. trackingIdentifier needs to be set to use
-   * session specific methods for starting trips or monitoring sites. This identifier will be persisted across
-   * application restarts.
-   *
-   * When the user logs out, set this to nil, which will in turn end the user session or monitoring session.
-   * Note: The maximum length of the trackingIdentifier is 36 characters.
-   **/
-  Curbside.setTrackingIdentifier("USER_UNIQUE_TRACKING_ID", function(error){
-
-  });
-
-  /**
-   * Returns the "USER_UNIQUE_TRACKING_ID" of the currently tracked user.
-   **/
-  Curbside.getTrackingIdentifier(function(error, trackingIdentifier){
-
-  });
-
-});
-</script>
-```
 
 ### Promise
 

--- a/src/android/com/curbside/CurbsideCordovaPlugin.java
+++ b/src/android/com/curbside/CurbsideCordovaPlugin.java
@@ -10,7 +10,6 @@ import android.content.Context;
 import android.location.Location;
 import android.os.Build;
 
-import com.curbside.sdk.CSMonitoringSession;
 import com.curbside.sdk.CSMotionActivity;
 import com.curbside.sdk.CSConstants;
 import com.curbside.sdk.CSSession;
@@ -64,11 +63,6 @@ public class CurbsideCordovaPlugin extends CordovaPlugin {
             subscribe(userSession, Type.APPROACHING_SITE, "userApproachingSite");
             subscribe(userSession, Type.ARRIVED_AT_SITE, "userArrivedAtSite");
             subscribe(userSession, Type.UPDATED_TRACKED_SITES, "updatedTrackedSites");
-        }
-
-        CSMonitoringSession monitoringSession = CSMonitoringSession.getInstance();
-        if (monitoringSession != null) {
-            subscribe(monitoringSession, Type.FETCH_LOCATION_UPDATE, "userStatusUpdates");
         }
     }
 
@@ -330,13 +324,6 @@ public class CurbsideCordovaPlugin extends CordovaPlugin {
                 case ETA_FROM_SITE:
                     callbackContext.error("CSUserSession must be initialized");
                     break;
-                case START_MONITORING_ARRIVALS:
-                case STOP_MONITORING_ARRIVALS:
-                case NOTIFY_MONITORING_SESSION_USER:
-                case COMPLETE_TRIP_FOR_TRACKING_IDENTIFIER:
-                case CANCEL_TRIP_FOR_TRACKING_IDENTIFIER:
-                    callbackContext.error("CSMonitoringSession must be initialized");
-                    break;
             }
         } else {
             Subscriber<Event> subscriber = new Subscriber<Event>() {
@@ -428,17 +415,8 @@ public class CurbsideCordovaPlugin extends CordovaPlugin {
             switch (action) {
                 case "setTrackingIdentifier": {
                     String trackingIdentifier = this.getStringArg(args, 0);
-                    CSMonitoringSession monitoringSession = CSMonitoringSession.getInstance();
                     CSUserSession userSession = CSUserSession.getInstance();
-                    if (monitoringSession != null) {
-                        if (trackingIdentifier != null) {
-                            listenNextEvent(monitoringSession, Type.REGISTER_TRACKING_ID, callbackContext);
-                            monitoringSession.registerTrackingIdentifier(trackingIdentifier);
-                        } else {
-                            listenNextEvent(monitoringSession, Type.UNREGISTER_TRACKING_ID, callbackContext);
-                            monitoringSession.unregisterTrackingIdentifier();
-                        }
-                    } else if (userSession != null) {
+                    if (userSession != null) {
                         if (trackingIdentifier != null) {
                             listenNextEvent(userSession, Type.REGISTER_TRACKING_ID, callbackContext);
                             userSession.registerTrackingIdentifier(trackingIdentifier);
@@ -556,11 +534,8 @@ public class CurbsideCordovaPlugin extends CordovaPlugin {
                     break;
                 }
                 case "getTrackingIdentifier": {
-                    CSMonitoringSession monitoringSession = CSMonitoringSession.getInstance();
                     CSUserSession userSession = CSUserSession.getInstance();
-                    if (monitoringSession != null) {
-                        callbackContext.success(monitoringSession.getTrackingIdentifier());
-                    } else if (userSession != null) {
+                    if (userSession != null) {
                         callbackContext.success(userSession.getTrackingIdentifier());
                     } else {
                         callbackContext.error("CSSession must be initialized");
@@ -619,51 +594,6 @@ public class CurbsideCordovaPlugin extends CordovaPlugin {
                         userSession.getEtaToSiteWithIdentifier(siteID, location, transportationMode);
                     } else {
                         callbackContext.error("CSUserSession must be initialized");
-                    }
-                    break;
-                }
-                case "completeTripForTrackingIdentifier": {
-                    CSMonitoringSession monitoringSession = CSMonitoringSession.getInstance();
-                    if (monitoringSession != null) {
-                        String trackingIdentifier = this.getStringArg(args, 0);
-                        List<String> trackTokens = this.getArrayArg(args, 1);
-                        listenNextEvent(monitoringSession, Type.COMPLETE_TRIP_FOR_TRACKING_IDENTIFIER, callbackContext);
-                        monitoringSession.completeTripForTrackingIdentifier(trackingIdentifier, trackTokens);
-                    } else {
-                        callbackContext.error("CSMonitoringSession must be initialized");
-                    }
-                    break;
-                }
-                case "cancelTripForTrackingIdentifier": {
-                    CSMonitoringSession monitoringSession = CSMonitoringSession.getInstance();
-                    if (monitoringSession != null) {
-                        String trackingIdentifier = this.getStringArg(args, 0);
-                        List<String> trackTokens = this.getArrayArg(args, 1);
-                        listenNextEvent(monitoringSession, Type.CANCEL_TRIP_FOR_TRACKING_IDENTIFIER, callbackContext);
-                        monitoringSession.cancelTripForTrackingIdentifier(trackingIdentifier, trackTokens);
-                    } else {
-                        callbackContext.error("CSMonitoringSession must be initialized");
-                    }
-                    break;
-                }
-                case "startMonitoringArrivalsToSiteWithIdentifier": {
-                    CSMonitoringSession monitoringSession = CSMonitoringSession.getInstance();
-                    if (monitoringSession != null) {
-                        String siteID = this.getStringArg(args, 0);
-                        listenNextEvent(monitoringSession, Type.START_MONITORING_ARRIVALS, callbackContext);
-                        monitoringSession.startMonitoringArrivalsToSiteWithIdentifier(siteID);
-                    } else {
-                        callbackContext.error("CSMonitoringSession must be initialized");
-                    }
-                    break;
-                }
-                case "stopMonitoringArrivals": {
-                    CSMonitoringSession monitoringSession = CSMonitoringSession.getInstance();
-                    if (monitoringSession != null) {
-                        listenNextEvent(monitoringSession, Type.STOP_MONITORING_ARRIVALS, callbackContext);
-                        monitoringSession.stopMonitoringArrivals();
-                    } else {
-                        callbackContext.error("CSMonitoringSession must be initialized");
                     }
                     break;
                 }

--- a/src/ios/CurbsideCordovaPlugin.h
+++ b/src/ios/CurbsideCordovaPlugin.h
@@ -41,15 +41,4 @@
 
 - (void)notifyMonitoringSessionUserOfArrivalAtSite:(CDVInvokedUrlCommand*)command;
 
-
-// monitoring session
-
-- (void)completeTripForTrackingIdentifier:(CDVInvokedUrlCommand*)command;
-
-- (void)cancelTripForTrackingIdentifier:(CDVInvokedUrlCommand*)command;
-
-- (void)startMonitoringArrivalsToSiteWithIdentifier:(CDVInvokedUrlCommand*)command;
-
-- (void)stopMonitoringArrivals:(CDVInvokedUrlCommand*)command;
-
 @end

--- a/www/plugin.js
+++ b/www/plugin.js
@@ -96,22 +96,6 @@ var Curbside = {
         return execCb("getEtaToSiteWithIdentifier", cb, siteId, location, transportationMode);
     },
 
-    completeTripForTrackingIdentifier: function(trackingIdentifier, trackTokens, cb) {
-        return execCb("completeTripForTrackingIdentifier", cb, trackingIdentifier, trackTokens);
-    },
-
-    cancelTripForTrackingIdentifier: function(trackingIdentifier, trackTokens, cb) {
-        return execCb("cancelTripForTrackingIdentifier", cb, trackingIdentifier, trackTokens);
-    },
-
-    startMonitoringArrivalsToSiteWithIdentifier: function(siteID, cb) {
-        return execCb("startMonitoringArrivalsToSiteWithIdentifier", cb, siteID);
-    },
-
-    stopMonitoringArrivals: function(cb) {
-        return execCb("stopMonitoringArrivals", cb);
-    },
-
     notifyMonitoringSessionUserOfArrivalAtSite: function(siteId, cb) {
         return execCb("notifyMonitoringSessionUserOfArrivalAtSite", cb, siteId);
     },


### PR DESCRIPTION
https://github.com/RakutenReady/Team/issues/53303

CSMonitoringSession cannot cohabit with CSUserSession the way it was initially done in the Cordova plugin, so keeping only CSUserSession code, which is what our clients want to use.